### PR TITLE
Fix profile edit card title alignment

### DIFF
--- a/src/argon-stubs/resources/views/profile/edit.blade.php
+++ b/src/argon-stubs/resources/views/profile/edit.blade.php
@@ -69,7 +69,7 @@
                 <div class="card bg-secondary shadow">
                     <div class="card-header bg-white border-0">
                         <div class="row align-items-center">
-                            <h3 class="mb-0">{{ __('Edit Profile') }}</h3>
+                            <h3 class="col-12 mb-0">{{ __('Edit Profile') }}</h3>
                         </div>
                     </div>
                     <div class="card-body">


### PR DESCRIPTION
# Fix profile edit card title alignment

Wanted to make a small contribution to this repo by fixing a style bug I found. I noticed that in the profile page the `"Edit Profile"` title in the card didn't have proper padding to the left. The issue here was that the class `row` is being used in the parent `div` but no `col-*` class was being used in the title `div`.

I could have fixed it by removing the `row` class instead of adding `col-12` but I decided to fix it this way to be consistent with the other card headers. Let me know if that's ok or you'd like the other way around better.

### Before

![image](https://user-images.githubusercontent.com/9297073/57963478-1b339300-78fb-11e9-9401-7c003dcbdb08.png)

-----

### After

![image](https://user-images.githubusercontent.com/9297073/57963481-21c20a80-78fb-11e9-94b5-c4fede169314.png)
